### PR TITLE
export Loop type

### DIFF
--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -1,4 +1,5 @@
 import type { SvelteComponent } from 'svelte'
+import { Loop } from './loop.svelte'
 
 declare module 'svelte-mainloop' {
    export class JoinLoop extends SvelteComponent { }

--- a/src/lib/loop.svelte.js
+++ b/src/lib/loop.svelte.js
@@ -2,7 +2,7 @@
 
 import MainLoop from './mainloop.js'
 
-class Loop {
+export class Loop {
    /** @type {Object.<StageString, Function[]>} */
    functions = $state({
       begin: [],


### PR DESCRIPTION
The `Loop` type was unresolved in `index.d.ts`. This PR simply exports the class from `loop.svelte.js` and imports it into `index.d.ts` so that the existing default `loop` export gets typed as expected.